### PR TITLE
Add direct reference to eslint-plugin-react

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,6 +39,6 @@
         "experimentalObjectRestSpread": true
     },
     "plugins": [
-        "react"
+        "@yuzu/yep-eslint-config/node_modules/eslint-plugin-react"
     ]
 }


### PR DESCRIPTION
If the developer does not have eslint-plugin-react installed globally, we need to reference it directly in our .eslintrc file in the same way we did with babel-eslint. 

@pbouzakis, when you get a chance can you offer your thoughts? @jfkhoury thought that this is a bad practice since it makes assumptions about the greater architecture of the app. Other alternatives that I can think of are:
1. going back to the original idea of two separate config files
2. keep this as before, but in the readme ask the developer to install babel-eslint and eslint-react-plugin
3. some other better way I can't think of at the moment! Maybe this was what we meant by bin file?
